### PR TITLE
Add reusable city links partial

### DIFF
--- a/layouts/partials/city-links.html
+++ b/layouts/partials/city-links.html
@@ -1,0 +1,6 @@
+{{ $locations := where .Site.RegularPages "Section" "locations" }}
+<div class="city-links">
+  {{ range sort $locations "Title" }}
+    <a href="{{ .RelPermalink }}">{{ .Title }}</a>
+  {{ end }}
+</div>

--- a/themes/armed-neon/layouts/locations/single.html
+++ b/themes/armed-neon/layouts/locations/single.html
@@ -49,18 +49,7 @@
             
             <div class="sidebar-card">
                 <h3>Service Areas</h3>
-                <div class="city-links">
-                    <a href="/locations/pasadena/">Pasadena</a>
-                    <a href="/locations/arcadia/">Arcadia</a>
-                    <a href="/locations/monrovia/">Monrovia</a>
-                    <a href="/locations/san-gabriel/">San Gabriel</a>
-                    <a href="/locations/altadena/">Altadena</a>
-                    <a href="/locations/south-pasadena/">South Pasadena</a>
-                    <a href="/locations/san-marino/">San Marino</a>
-                    <a href="/locations/sierra-madre/">Sierra Madre</a>
-                    <a href="/locations/la-canada-flintridge/">La Cañada Flintridge</a>
-                    <a href="/locations/rosemead/">Rosemead</a>
-                </div>
+                {{ partial "city-links.html" . }}
             </div>
         </aside>
     </div>


### PR DESCRIPTION
## Summary
- create a `city-links` partial to list all locations dynamically
- use the new partial in the location page template

## Testing
- `bash scripts/setup_codex.sh`
- `bash scripts/check_site.sh`

------
https://chatgpt.com/codex/tasks/task_e_685e97edb528832ea7900685133ac40a